### PR TITLE
feat: click session ID to copy to clipboard

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -137,6 +137,17 @@ function ThreadView() {
   // SSE event handlers use useGazeboStore.getState() directly
   // to avoid stale closures in EventSource listeners
 
+  // Clipboard copy state for session ID
+  const [copied, setCopied] = useState(false);
+
+  const handleCopySessionId = useCallback(() => {
+    if (!sessionId) return;
+    navigator.clipboard.writeText(sessionId).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [sessionId]);
+
   // Track the current assistant message ID for SSE event routing
   const currentAssistantIdRef = useRef<string | null>(null);
 
@@ -396,9 +407,13 @@ function ThreadView() {
           </Link>
           <div className="flex items-center gap-4">
             {sessionId && (
-              <span className="font-mono text-xs text-muted">
-                {sessionId.slice(0, 8)}...
-              </span>
+              <button
+                onClick={handleCopySessionId}
+                className="font-mono text-xs text-muted bg-transparent border-none cursor-pointer hover:text-foreground transition-colors"
+                title={sessionId}
+              >
+                {copied ? "Copied!" : `${sessionId.slice(0, 8)}...`}
+              </button>
             )}
             <ContextMeter inputTokens={inputTokens} />
           </div>


### PR DESCRIPTION
Converts the truncated session ID display in the header from a static span to a clickable button. Clicking it copies the full session ID via navigator.clipboard.writeText() and briefly shows "Copied!" for 2 seconds as visual confirmation.

Closes #13

Generated with [Claude Code](https://claude.ai/code)