### PR TITLE
Remove model label from composer area

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -448,13 +448,6 @@ function ThreadView() {
                 {/* Add attachment button */}
                 <ComposerAddAttachment />
 
-                <span
-                  className="font-serif text-muted"
-                  style={{ fontSize: `${14 * fontScale}px` }}
-                >
-                  Opus 4.6
-                </span>
-
                 {/* Send button (always visible — queueing allowed) */}
                 <ComposerPrimitive.Send className="w-9 h-9 flex items-center justify-center bg-primary border-none rounded-lg text-white cursor-pointer">
                   <ArrowUp size={20} strokeWidth={2.5} />


### PR DESCRIPTION
Removes the hardcoded "Opus 4.6" label from the composer footer, so the attach button and send button are now adjacent.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)